### PR TITLE
Fix undefined variable in Storage.Inline

### DIFF
--- a/interface.zig
+++ b/interface.zig
@@ -143,7 +143,7 @@ pub const Storage = struct {
                             .mem = undefined,
                         };
                         if (ImplSize > 0) {
-                            std.mem.copy(u8, self.mem[0..], @ptrCast([*]const u8, &args[0])[0..ImplSize]);
+                            std.mem.copy(u8, self.mem[0..], std.mem.asBytes(value)[0..ImplSize]);
                         }
 
                         return TInterface{


### PR DESCRIPTION
`args` variable was undefined, this commit fixes it.

I don't know what is wrong with the `comptime try InlineTest.run()` :-/

And thanks for the library, very nice to learn comptime zig things :-)